### PR TITLE
Add rack to dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     ovto (0.4.0)
       opal (~> 0.11)
+      rack (~> 2.0)
       thor (~> 0.20)
 
 GEM

--- a/ovto.gemspec
+++ b/ovto.gemspec
@@ -20,4 +20,5 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "opal", '~> 0.11'
   spec.add_dependency "thor", '~> 0.20'
+  spec.add_dependency "rack", '~> 2.0'
 end


### PR DESCRIPTION
When I executed `ovto` command, the following message was displayed.

```
cannot load such file -- rack (LoadError)
```

`rack` is required in `exe/ovto` file, so I added `rack` as gem's dependency.