### PR TITLE
Suppress regexp warning of "character calss has duplicated range"

### DIFF
--- a/lib/ovto/component.rb
+++ b/lib/ovto/component.rb
@@ -122,9 +122,9 @@ module Ovto
 
     def extract_attrs(tag_name)
       case tag_name 
-      when /^([^.#]*)\.([-_\w]+)(\#([-_\w]+))?/  # a.b#c
+      when /^([^.#]*)\.([-\w]+)(\#([-\w]+))?/  # a.b#c
         tag_name, class_name, id = ($1.empty? ? 'div' : $1), $2, $4
-      when /^([^.#]*)\#([-_\w]+)(\.([-_\w]+))?/  # a#b.c
+      when /^([^.#]*)\#([-\w]+)(\.([-\w]+))?/  # a#b.c
         tag_name, class_name, id = ($1.empty? ? 'div' : $1), $4, $2
       else
         class_name = id = nil


### PR DESCRIPTION
It displays the following warnings.


```
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/opal-0.11.4/lib/opal/nodes/literal.rb:152: warning: character class has duplicated range: /^([^.#]*)\.([-_\w]+)(\#([-_\w]+))?/
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/opal-0.11.4/lib/opal/nodes/literal.rb:152: warning: character class has duplicated range: /^([^.#]*)\#([-_\w]+)(\.([-_\w]+))?/
```

Because `\w` includes `_`.

This pull request will suppress the warnings.