### PR TITLE
Relax Opal version to use Opal v1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     ovto (0.4.1)
-      opal (~> 0.11)
+      opal (>= 0.11, < 2)
       rack (~> 2.0)
       thor (~> 0.20)
 
@@ -49,4 +49,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.0.1
+   2.0.2

--- a/ovto.gemspec
+++ b/ovto.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "opal", '~> 0.11'
+  spec.add_dependency "opal", '>= 0.11', '< 2'
   spec.add_dependency "thor", '~> 0.20'
   spec.add_dependency "rack", '~> 2.0'
 end


### PR DESCRIPTION
Problem
===


Opal v1 has been released. :tada:
I'd like to use Opal v1 with Ovto for my project, but it cannot. Because Ovto restricts Opal version as `~> 0.11`.

Solution
===


Relax the dependency to allow Opal v1.

Note
===


Ovto still uses Opal v0.11.4 for developing itself because opal-rspec has a restriction for Opal v0.11.
It has been relaxed already, but it isn't released yet.
https://github.com/opal/opal-rspec/commit/6805d15131d65852264919165977090d42920876


I've confirmed Ovto works with Opal v1 in my local. But it needs to build opal-rspec gem in the local.
So I'll open an issue to ask the opal team to release a new version to rubygems.org.


---


Thank you for the great product!